### PR TITLE
AudioPlayResm common interface for AudioPlayArrayResmp and AudioPlaySDResmp

### DIFF
--- a/src/playarrayresmp.h
+++ b/src/playarrayresmp.h
@@ -9,12 +9,13 @@
 #include "Arduino.h"
 #include "AudioStream.h"
 #include "ResamplingArrayReader.h"
+#include "playresmp.h"
 
-class AudioPlayArrayResmp : public AudioStream
+class AudioPlayArrayResmp : public AudioPlayResmp
 {
 public:
     AudioPlayArrayResmp(void) :
-            AudioStream(0, NULL),
+            AudioPlayResmp(),
             arrayReader()
     {
         begin();

--- a/src/playresmp.h
+++ b/src/playresmp.h
@@ -1,9 +1,9 @@
 #ifndef TEENSY_RESAMPLING_SDREADER_PLAYRESMP_H
 #define TEENSY_RESAMPLING_SDREADER_PLAYRESMP_H
 
-#include <Arduino.h>
-#include <Audio.h>
-#include <loop_type.h>
+#include "Arduino.h"
+#include "Audio.h"
+#include "loop_type.h"
 
 class AudioPlayResmp : public AudioStream
 {

--- a/src/playresmp.h
+++ b/src/playresmp.h
@@ -1,0 +1,24 @@
+#ifndef TEENSY_RESAMPLING_SDREADER_PLAYRESMP_H
+#define TEENSY_RESAMPLING_SDREADER_PLAYRESMP_H
+
+#include <Arduino.h>
+#include <Audio.h>
+#include <loop_type.h>
+
+class AudioPlayResmp : public AudioStream
+{
+    public:
+        AudioPlayResmp(void): AudioStream(0, NULL) {}
+        virtual ~AudioPlayResmp() {}
+
+        virtual void setPlaybackRate(float f) = 0;
+        virtual void setLoopType(loop_type t) = 0;
+        virtual void setLoopStart(uint32_t loop_start) = 0;
+        virtual void setLoopFinish(uint32_t loop_finish) = 0;
+        virtual void begin() = 0;
+        virtual void enableInterpolation(bool enable) = 0;
+        virtual bool isPlaying(void) = 0;
+        virtual void stop() = 0;
+};
+
+#endif // TEENSY_RESAMPLING_SDREADER_PLAYRESMP_H

--- a/src/playsdresmp.h
+++ b/src/playsdresmp.h
@@ -11,12 +11,13 @@
 #include "SD.h"
 #include "stdint.h"
 #include "ResamplingSdReader.h"
+#include "playresmp.h"
 
-class AudioPlaySdResmp : public AudioStream
+class AudioPlaySdResmp : public AudioPlayResmp
 {
 public:
     AudioPlaySdResmp(void) :
-            AudioStream(0, NULL),
+            AudioPlayResmp(),
             sdReader()
     {
         begin();
@@ -37,6 +38,14 @@ public:
 
     void setLoopType(loop_type t) {
         sdReader.setLoopType(t);
+    }
+
+    void setLoopStart(uint32_t loop_start) {
+        sdReader.setLoopStart(loop_start);
+    }
+
+    void setLoopFinish(uint32_t loop_finish) {
+        sdReader.setLoopFinish(loop_finish);
     }
 
     void enableInterpolation(bool enable) {


### PR DESCRIPTION
I added a common class to both `AudioPlayArrayResmp` and `AudioPlaySDResmp` to make switching between those two easier. They already shared most of the API. I left the `playWav` and `playRaw` out of the interface and did not change them.

This change should be API-compatibile and not add too much of rigidity to the codebase.

The way I use it is to keep 3 pointers side-by-side:

```
    AudioPlayArrayResmp *arrayPlayer = NULL;
    AudioPlaySdResmp *sdPlayer = NULL;
    AudioPlayResmp *player = NULL;
```

Next, I assign them based on what is needed during construction:

```
    if(directPlay) {
        sdPlayer = new AudioPlaySdResmp();
        player = sdPlayer;
    } else {
        arrayPlayer = new AudioPlayArrayResmp();
        player = arrayPlayer;
    }
```

Thanks to this change I can keep the rest of the code independent of the source and only branch out the actual playWav:

```
    if(arrayPlayer != NULL) {
        playing = arrayPlayer->playWav((unsigned int *)sample->buf, sample->fileSize / 2);
    } else {
        playing = sdPlayer->playWav(sample->filename);
    }
```