### PR TITLE
When playing a mono sample, transmit on both channels

### DIFF
--- a/src/playarrayresmp.cpp
+++ b/src/playarrayresmp.cpp
@@ -67,6 +67,10 @@ void AudioPlayArrayResmp::update()
             }
             transmit(blocks[channel], channel);
         }
+
+        if(_numChannels == 1) {
+            transmit(blocks[0], 1);
+        }
     } else {
         arrayReader.close();
     }

--- a/src/playsdresmp.cpp
+++ b/src/playsdresmp.cpp
@@ -60,6 +60,10 @@ void AudioPlaySdResmp::update()
             }
             transmit(blocks[channel], channel);
         }
+
+        if(_numChannels == 1) {
+            transmit(blocks[0], 1);
+        }
     } else {
         sdReader.close();
     }


### PR DESCRIPTION
While it's possible to solve this using two connections but this method is much easier to manage when playing a mixture of stereo and mono audio files. 