### PR TITLE
Fix error playing WAV data from RAM

### DIFF
--- a/src/ResamplingReader.h
+++ b/src/ResamplingReader.h
@@ -83,7 +83,7 @@ public:
                 break;
                         
             result = playRaw((TArray*)((char*) array + (36 + infoTagsSize + sizeof wav_data_hdr)), 
-                             wav_data_hdr.data_bytes / 2, 
+                             wav_data_hdr.data_bytes / hdr.num_channels / 2, 
                              hdr.num_channels); 
         } while (0);
         


### PR DESCRIPTION
The computation of the number of samples didn't take into account the number of channels ... oops